### PR TITLE
Reuse the API token where possible

### DIFF
--- a/code/00 - Get Scottish data.R
+++ b/code/00 - Get Scottish data.R
@@ -15,12 +15,19 @@ library(Hmisc)
 
 ## API pull
 
+# Get the API token for the CO-CIN database
+if (Sys.getenv("ccp_token") == "") {
+  Sys.setenv(ccp_token = rstudioapi::showPrompt(
+    title = "Enter API token",
+    message = "API token:"
+  ))
+} else {
+  message("Using stored token - If the token is incorrect run Sys.setenv(ccp_token = \"<TOKEN>\")")
+}
+
+
 ## The API call fail randomly due to traffic
 ## Try 5 times then stop
-Sys.setenv(ccp_token = rstudioapi::showPrompt(
-  title = "Enter API token",
-  message = "API token:"
-))
 tries <- 0
 extract <- NA
 


### PR DESCRIPTION
Improved comments and made it so the API token will be reused when running subsequent extracts in the same session