### PR TITLE
Simplify function to avoid warnings

### DIFF
--- a/functions/latest_extract_date.R
+++ b/functions/latest_extract_date.R
@@ -1,13 +1,11 @@
 # function to take latest extract from data folder
 
-latest_extract_date <- function(){
-  
-  list.files(here("data")) %>%
+latest_extract_date <- function() {
+  list.files(here("data"),
+    pattern = "^\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}_"
+  ) %>%
     str_sub(1, 16) %>%
-    ymd_hm() %>%
-    max(na.rm = TRUE) %>%
-    format("%Y-%m-%d_%H-%M")
-  
+    max()
 }
 
 


### PR DESCRIPTION
Was getting a 'Failed to parse' warning when converting to date. Use regex to only select relevant files and use max based on string name